### PR TITLE
Resolve a bug when testing with error code

### DIFF
--- a/Service/Etransactions.php
+++ b/Service/Etransactions.php
@@ -115,7 +115,7 @@ class Etransactions
         $retour['ref'] = $query['ref'];
         $retour['amount'] = $query['amount'];
         $retour['error'] = $query['error'];
-        $retour['auto'] = $query['auto'];
+        $retour['auto'] = $query['auto'] ?: null;
 
         // Check signature
         if (!empty($query['sign']) && $this->check_signature === true)


### PR DESCRIPTION
Hello ! 😃 

First, thanks you for this bundle ! It helps me a lot when I develop e-commerce sites on Symfony.

I wanted to perform a test with an error code inside like this : 
```php
$etransactions = $this->get("snowbaha.etransactions")
        ->init(strtoupper($name).'_'. strtoupper($purchase->getReference()), $prix_TTC , $exhibitor->getEmailCanonical())
        ->setOptionnalFields(array(
            'effectue' => $link_success,
            'refuse' => $link_error,
            'repondre_a' => $link_confirm,
            'annule' => $link_error,
            'errorcodetest' => "00133" // Carte expirée 
));
```

The bank return all data the bundle wanted but just one is missing, the "auto" key.

![image](https://user-images.githubusercontent.com/23474605/112030986-20874780-8b3b-11eb-8832-59d9129b5d13.png)

![image](https://user-images.githubusercontent.com/23474605/112032946-3433ad80-8b3d-11eb-9826-a65372f81b9b.png)

I just added a condition to return null when the key is missing into the query.

It's my really first pull request, so I hope I was clear with my explications. :monocle_face: :fearful:

Thanks you !